### PR TITLE
Fix OLS crash on singular matrices by adding regularization fallback

### DIFF
--- a/python/test/ols.py
+++ b/python/test/ols.py
@@ -1,12 +1,13 @@
 import better_tensorflow as btf
 
-# X = [[1, 2], [2, 3], [3, 4]], Y = [5, 8, 11]
+# Data
 x = [[1.0, 2.0], [2.0, 3.0], [3.0, 4.0]]
 y = [5.0, 8.0, 11.0]
 
+# Train OLS model
 weights = btf.train_ols(x, y)
-print("Poids appris:", weights)
+print("Learned weights:", weights)
 
-# Prédiction
+# Predict
 preds = btf.predict_ols(x, weights)
-print("Prédictions:", preds)
+print("Predictions:", preds)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,10 @@ fn predict_ols(x_data: Vec<Vec<f32>>, weights: Vec<f32>) -> PyResult<Vec<f32>> {
     Ok(ols::predict_ols(x_data, weights))
 }
 
+#[pyfunction]
+fn train_ols_robust(x_data: Vec<Vec<f32>>, y_data: Vec<f32>) -> PyResult<Vec<f32>> {
+    ols::train_ols_robust(x_data, y_data)
+}
 
 
 #[pymodule]
@@ -151,6 +155,7 @@ fn better_tensorflow(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_function(wrap_pyfunction!(train_ols, m)?)?;
     m.add_function(wrap_pyfunction!(predict_ols, m)?)?;
+    m.add_function(wrap_pyfunction!(train_ols_robust, m)?)?;
 
 
     Ok(())

--- a/src/math.rs
+++ b/src/math.rs
@@ -85,3 +85,44 @@ pub fn multiply_matrix_vector(matrix: &Vec<Vec<f32>>, vector: &Vec<f32>) -> Vec<
 
     result
 }
+
+/// inverse cas : Matrice singulière
+pub fn try_inverse(matrix: &Vec<Vec<f32>>) -> Option<Vec<Vec<f32>>> {
+    let n = matrix.len();
+    let mut result = vec![vec![0.0; n]; n];
+    let mut a = matrix.clone();
+
+    // init matrice identité I
+    for i in 0..n {
+        result[i][i] = 1.0;
+    }
+
+    // Gauss Jordan elimination & verification
+    for i in 0..n {
+        let pivot = a[i][i];
+
+        // Vérifier si le pivot est trop petit
+        if pivot.abs() < 1e-8 {
+            return None;  // failed : matrice non inversible
+        }
+
+        // pivot row normalisation
+        for j in 0..n {
+            a[i][j] /= pivot;
+            result[i][j] /= pivot;
+        }
+
+        // remove other rows ...
+        for k in 0..n {
+            if k != i {
+                let factor = a[k][i];
+                for j in 0..n {
+                    a[k][j] -= factor * a[i][j];
+                    result[k][j] -= factor * result[i][j];
+                }
+            }
+        }
+    }
+
+    Some(result)
+}

--- a/src/ols.rs
+++ b/src/ols.rs
@@ -1,6 +1,7 @@
 use crate::data_converter;
 use crate::math::{xtx, xty, inverse, multiply_matrix_vector};
-
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 /// Trains linear regression weights: W = (X^T X)^(-1) X^T Y
 pub fn train_ols(x: Vec<Vec<f32>>, y: Vec<f32>) -> Vec<f32> {
     let xtx_ = xtx(&x);
@@ -25,4 +26,61 @@ pub fn predict_ols(x: Vec<Vec<f32>>, weights: Vec<f32>) -> Vec<f32> {
     }
 
     predictions
+}
+
+
+pub fn train_ols_robust(x: Vec<Vec<f32>>, y: Vec<f32>) -> PyResult<Vec<f32>> {
+    let xtx_ = xtx(&x);
+    let xty_ = xty(&x, &y);
+
+    // Try normal inversion
+    let xtx_inv = match crate::math::try_inverse(&xtx_) {
+        Some(inv) => {
+            println!("Inversion succeeded");
+            inv
+        }
+        None => {
+            println!("Inversion failed, adding λ=1e-4");
+
+            // Try with small λ
+            let lambda = 1e-4;
+            let mut xtx_reg = xtx_.clone();
+            for i in 0..xtx_reg.len() {
+                xtx_reg[i][i] += lambda;
+            }
+
+            match crate::math::try_inverse(&xtx_reg) {
+                Some(inv) => {
+                    println!("Inversion succeeded with λ=1e-4");
+                    inv
+                }
+                None => {
+                    println!("Inversion failed again, trying with λ=1e-2");
+
+                    // Try with larger λ
+                    let lambda_big = 1e-2;
+                    let mut xtx_reg_big = xtx_.clone();
+                    for i in 0..xtx_reg_big.len() {
+                        xtx_reg_big[i][i] += lambda_big;
+                    }
+
+                    match crate::math::try_inverse(&xtx_reg_big) {
+                        Some(inv) => {
+                            println!("Inversion succeeded with λ=1e-2");
+                            inv
+                        }
+                        None => {
+                            return Err(PyValueError::new_err(
+                                "La matrice X^T X est trop mal conditionnée même après régularisation (λ).",
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    let weights = multiply_matrix_vector(&xtx_inv, &xty_);
+    data_converter::export_weights_ols(&weights);
+    Ok(weights)
 }


### PR DESCRIPTION
Add fallback in train_ols_robust using Tikhonov regularization (λ=1e-4, then 1e-2) to handle singular matrices

**pourquoi ?**:  
Prevents crashes when \( X^T X \) is non-invertible -->  improves training stability. 

**Cas de test :** # Test 4: R3D Linear Regression - Tricky
